### PR TITLE
Added mobile to supported platforms

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,5 +8,6 @@
 	"author": "Hieu-Thi Luong",
 	"homepage_url": "https://github.com/hieuthi/joplin-plugin-life-calendar",
 	"repository_url": "https://github.com/hieuthi/joplin-plugin-life-calendar",
-	"keywords": ["joplin-plugin", "life calendar", "week calendar", "life", "timeline"]
+	"keywords": ["joplin-plugin", "life calendar", "week calendar", "life", "timeline"],
+	"platforms": ["desktop", "mobile"]
 }


### PR DESCRIPTION
This PR adds support for Joplin mobile, resolving #4. 

The `platforms` property was added to the manifest, which now specifies both desktop and mobile as supported platforms.